### PR TITLE
Fix toggle 🍔 menu in mobile

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -121,7 +121,8 @@ $("#toggle-menu").click(function(){
     $("#menu").toggleClass("dn");
 });
 $("#menu li a").click(function(){
-    $("#menu").toggleClass("dn");
+    $("#menu").addClass("dn");
+    $("#toggle-menu").removeClass("menu-opened");
   });
 
 //animacion


### PR DESCRIPTION
Fix para el comportamiento actual en _mobile_ 👇
![nodeconf](https://user-images.githubusercontent.com/784056/28242927-9f9b57de-69b9-11e7-8245-46d7ec9845a3.gif)

Al hacer `click` en los items, ahora se encarga no solo de esconder la lista, sino también de volver el _status_ de la ❎ en 🍔.